### PR TITLE
Fix `CameraShakerInstance:UpdateShake`'s timestep

### DIFF
--- a/src/CameraShaker/CameraShakeInstance.lua
+++ b/src/CameraShaker/CameraShakeInstance.lua
@@ -91,10 +91,10 @@ function CameraShakeInstance:UpdateShake(dt)
 		else
 			self.tick = _tick + (TICK_RATE * self.Roughness * self.roughMod * currentFadeTime)
 		end
-
-		self.currentFadeTime = currentFadeTime
 	end
-	
+
+	self.currentFadeTime = currentFadeTime
+
 	return offset * self.Magnitude * self.magnMod * currentFadeTime
 	
 end

--- a/src/CameraShaker/CameraShakeInstance.lua
+++ b/src/CameraShaker/CameraShakeInstance.lua
@@ -76,20 +76,20 @@ function CameraShakeInstance:UpdateShake(dt)
 
 		if (self.fadeInDuration > 0 and self.sustain) then
 			if (currentFadeTime < 1) then
-				currentFadeTime = currentFadeTime + (dt / self.fadeInDuration)
+				currentFadeTime = currentFadeTime + (TICK_RATE / self.fadeInDuration)
 			elseif (self.fadeOutDuration > 0) then
 				self.sustain = false
 			end
 		end
 
 		if (not self.sustain) then
-			currentFadeTime = currentFadeTime - (dt / self.fadeOutDuration)
+			currentFadeTime = currentFadeTime - (TICK_RATE / self.fadeOutDuration)
 		end
 
 		if (self.sustain) then
-			self.tick = _tick + (dt * self.Roughness * self.roughMod)
+			self.tick = _tick + (TICK_RATE * self.Roughness * self.roughMod)
 		else
-			self.tick = _tick + (dt * self.Roughness * self.roughMod * currentFadeTime)
+			self.tick = _tick + (TICK_RATE * self.Roughness * self.roughMod * currentFadeTime)
 		end
 
 		self.currentFadeTime = currentFadeTime


### PR DESCRIPTION
`CameraShakerInstance:UpdateShake` uses a variable timestep to perform the update, causing players with low FPS and players using FPS unlockers to experience very pronounced shaking. This PR changes `CameraShakerInstance:UpdateShake` to use a fixed timestep so that the effect is consistent regardless of FPS

Closes #4